### PR TITLE
Update the codeship link to be updated version

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # GDI TAMS
 
-![Codeship](https://codeship.io/projects/ceff6e60-cbc9-0131-1542-069c58d51f38/status)
+![Codeship Status for gdichicago/gdi-tams](https://codeship.com/projects/e87d9e80-d98c-0132-4083-663757f654ab/status?branch=stable)](https://codeship.com/projects/79037)
 
 TAMS: Teaching Assistant Management System
 


### PR DESCRIPTION
The codeship image on the README was outdated and pointing to an old version of the project. This PR changes the link so that it points to the correct project in codeship.